### PR TITLE
Fix automated key management (close #8)

### DIFF
--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -927,7 +927,7 @@
         <t>
           A node which does need to accept responses between sleep cycles will
           need to maintain the encryption key.  It may be stored into
-          available non-volatile storage once, provided that there is a
+          available non-volatile storage once (e.g., at boot time), provided that there is a
           reliably non-repeating source of nonces, such as sourcing from a
           counter that survives across sleep cycles.  Such a source may be
           available from the layer-2 network encryption mechanism.

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -885,7 +885,7 @@
 
         <t>
           When encryption is used, the use of <xref
-          target="RFC3610">AES-CCM</xref> with a 64-bit tag is RECOMMENDED,
+          target="RFC3610">AES-CCM</xref> with a 64-bit tag is recommended,
           combined with a sequence number and a replay window.
           This choice is informed by available hardware acceleration of on
           many constrained systems.

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -925,10 +925,10 @@
           cycle is advised.
         </t>
         <t>
-          A node which does need to accept response between sleep cycles will
+          A node which does need to accept responses between sleep cycles will
           need to maintain the encryption key.  It may be stored into
           available non-volatile storage once, provided that there is a
-          reliably non-repeating source of nonces, such sourcing from a
+          reliably non-repeating source of nonces, such as sourcing from a
           counter that survives across sleep cycles.  Such a source may be
           available from the layer-2 network encryption mechanism.
         </t>

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -913,24 +913,9 @@
         </t>
 
         <t>
-          A node which enters long-term sleeps may find it difficult to
-          maintain the state for a good pseudo-random number generated
-          appropriate for non-repeating nonce generation just for the
-          encryption of this state.
-        </t>
-
-        <t>
-          If a node does not need to accept responses across sleep cycles,
-          then generating a new key for encryption of state during each wake
-          cycle is advised.
-        </t>
-        <t>
-          A node which does need to accept responses between sleep cycles will
-          need to maintain the encryption key.  It may be stored into
-          available non-volatile storage once (e.g., at boot time), provided that there is a
-          reliably non-repeating source of nonces, such as sourcing from a
-          counter that survives across sleep cycles.  Such a source may be
-          available from the layer-2 network encryption mechanism.
+          <xref target="RFC8613" /> appendix B.1.1 ("Sender Sequence Number")
+          provides a model for how to maintain non-repeating nonces without
+          causing excessive wear of flash.
         </t>
       </section>
 
@@ -1002,6 +987,7 @@
       &RFC3610;
       &RFC6234;
       &RFC7228;
+      <?rfc include="reference.RFC.8613" ?>
 
       &I-D.ietf-core-echo-request-tag;
 

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -850,13 +850,18 @@
 
         <t>
           It is generally expected that the use of encryption, integrity
-          protection, and replay protection for serialized state is appropriate.
+          protection, and replay protection for serialized state is
+          appropriate.
+        </t>
 
+        <t>
           In the absence of integrity and reply protection, an on-path attacker
           or rogue server/intermediary could return a state (either one modified
           in a reply, or an unsolicited one) that could alter the internal state
           of the client.
+        </t>
 
+        <t>
           It is this reason that at least the use of integrity protection on
           the token is always recommended.
         </t>
@@ -864,24 +869,40 @@
         <t>
           It maybe that in some very specific case, as a result of a careful
           and detailed analysis of any potential attacks,  that there may be cases
-          where such cryptographic protections do not add value.  The authors
-          of this document have not found such a use case as yet.
+          where such cryptographic protections do not add value.
+          The authors of this document have not found such a use case as yet, but this
+          is a local decision.
         </t>
 
         <t>
-          <xref target="RFC3610">AES-CCM</xref> with a 64-bit tag is
-          RECOMMENDED, combined with a sequence number and a replay window.
+          It should further be emphasized that the encrypted state is created by the
+          sending node, and decrypted by the same node when receiving a
+          response.
+          The key is not shared with any other system.
+          Therefore the choice of encryption scheme and the generation of the key for
+          this system is purely a local matter.
+        </t>
 
-          Where encryption is not needed, <xref
+        <t>
+          When encryption is used, the use of <xref
+          target="RFC3610">AES-CCM</xref> with a 64-bit tag is RECOMMENDED,
+          combined with a sequence number and a replay window.
+          This choice is informed by available hardware acceleration of on
+          many constrained systems.
+          If a different algorithm is available accelerated on the sender,
+          with similar strength, then it SHOULD be preferred.
+
+          Where privacy of the state is not required, and encryption is not needed, <xref
           target="RFC6234">HMAC-SHA-256</xref>, combined with a sequence number
-          and a replay window, may be used.
+          and a replay window, MAY be used.
         </t>
 
         <t>
           When using an encryption mode that depends on a nonce, such as
           AES-CCM, repeated use of the same nonce under the same key
           causes the cipher to fail catastrophically.
-
+        </t>
+        <t>
           If a nonce is ever used for more than one encryption operation with
           the same key, then the same key stream gets used to encrypt both plaintexts and the
           confidentiality guarantees are voided. Devices with low-quality entropy
@@ -889,12 +910,28 @@
           happen to be a natural candidate for the stateless mechanism described
           in this document -- need to carefully pick a nonce generation
           mechanism that provides the above uniqueness guarantee.
-
-          Additionally, since it can be difficult to use AES-CCM securely when using
-          statically configured keys, implementations should use <xref
-          target="RFC4107">automated key management</xref>.
         </t>
 
+        <t>
+          A node which enters long-term sleeps may find it difficult to
+          maintain the state for a good pseudo-random number generated
+          appropriate for non-repeating nonce generation just for the
+          encryption of this state.
+        </t>
+
+        <t>
+          If a node does not need to accept responses across sleep cycles,
+          then generating a new key for encryption of state during each wake
+          cycle is advised.
+        </t>
+        <t>
+          A node which does need to accept response between sleep cycles will
+          need to maintain the encryption key.  It may be stored into
+          available non-volatile storage once, provided that there is a
+          reliably non-repeating source of nonces, such sourcing from a
+          counter that survives across sleep cycles.  Such a source may be
+          available from the layer-2 network encryption mechanism.
+        </t>
       </section>
 
     </section>

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -898,6 +898,30 @@
         </t>
 
         <t>
+          This size of the replay window depends upon the number of
+          outstanding requests that need to be outstanding.  This can be
+          determined from the rate at which new ones are made, and the
+          expected duration in which responses are expected.
+        </t>
+
+        <t>
+          For instance, given a CoAP ACK_TIMEOUT of 2s, and a request rate of
+          10 requests/second, any request that is not answered within 2s will
+          be considered to have failed.  Thus at most 20 request can be
+          outstanding at a time, and any convenient replay window larger than
+          20 will work.  As replay windows are often implemented with a
+          sliding window and a bit, the use of a 32-bit window would be
+          sufficient.
+        </t>
+        <t>
+          For use cases where requests are being relayed from another node,
+          the request rate may be estimated by the total link capacity
+          allocated for that kind of traffic.  An alternate view would
+          consider how many IPv6 Neighbor Cache Entries (NCEs) the system can
+          afford to allocate for this use.
+       </t>
+
+        <t>
           When using an encryption mode that depends on a nonce, such as
           AES-CCM, repeated use of the same nonce under the same key
           causes the cipher to fail catastrophically.

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -841,7 +841,8 @@
           serialized state information in the token has several significant and
           non-obvious security and privacy implications that need to be
           mitigated; see <xref target="serialized-state"/> for recommendations.
-
+        </t>
+        <t>
           In addition to the format requirements outlined there, implementations
           need to ensure that they are not vulnerable to maliciously crafted,
           delayed, or replayed tokens.
@@ -877,16 +878,19 @@
         </t>
 
         <t>
-          When using an encryption mode that depends on a nonce, such as AES-CCM, repeated use of the same nonce under the same key
-          causes the cipher to fail catastrophically. If a nonce is ever used
-          for more than one encryption operation with the same key, then the
-          same key stream gets used to encrypt both plaintexts and the
+          When using an encryption mode that depends on a nonce, such as
+          AES-CCM, repeated use of the same nonce under the same key
+          causes the cipher to fail catastrophically.
+
+          If a nonce is ever used for more than one encryption operation with
+          the same key, then the same key stream gets used to encrypt both plaintexts and the
           confidentiality guarantees are voided. Devices with low-quality entropy
           sources -- as is typical with constrained devices, which incidentally
           happen to be a natural candidate for the stateless mechanism described
           in this document -- need to carefully pick a nonce generation
-          mechanism that provides the above uniqueness guarantee. Additionally,
-          since it can be difficult to use AES-CCM securely when using
+          mechanism that provides the above uniqueness guarantee.
+
+          Additionally, since it can be difficult to use AES-CCM securely when using
           statically configured keys, implementations should use <xref
           target="RFC4107">automated key management</xref>.
         </t>

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -1000,7 +1000,6 @@
     <references title="Informative References">
 
       &RFC3610;
-      &RFC4107;
       &RFC6234;
       &RFC7228;
 

--- a/draft-ietf-core-stateless.xml
+++ b/draft-ietf-core-stateless.xml
@@ -894,7 +894,7 @@
 
           Where privacy of the state is not required, and encryption is not needed, <xref
           target="RFC6234">HMAC-SHA-256</xref>, combined with a sequence number
-          and a replay window, MAY be used.
+          and a replay window, may be used.
         </t>
 
         <t>


### PR DESCRIPTION
the automated key management reference was made in error. 
RFC4107 is about systems like IKEv2, TLS, etc. where a key has to be agreed upon between two (or more nodes).  The key needed for the encrypted state token never leaves the sender, so it can be a randomly generated key, provided that the nonce is never repeated.

This text fixed the considerations for this section.
